### PR TITLE
Feature/required translation attributes rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "laravel/framework": ">=8.0"
+        "laravel/framework": ">=9.2"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0@dev"

--- a/src/Rules/RequiredForLocale.php
+++ b/src/Rules/RequiredForLocale.php
@@ -2,6 +2,7 @@
 
 namespace Mabrouk\Translatable\Rules;
 
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
 
@@ -34,7 +35,7 @@ class RequiredForLocale implements ValidationRule
      *
      * @return void
      */
-    public function validate(string $attribute, mixed $value, \Closure $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (\is_null($value) && $this->modelObject->translationModelClass::where('locale', request()->input('locale'))->doesntExist()) {
             $fail('validation.required')->translate();

--- a/src/Rules/RequiredForLocale.php
+++ b/src/Rules/RequiredForLocale.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Mabrouk\Translatable\Rules;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Validation rule to ensure a required field for a specific locale.
+ * This rule should not be used with the `required` or `sometimes` rule.
+ */
+class RequiredForLocale implements ValidationRule
+{
+    /**
+     * Indicates that this rule is implicit, meaning it will be applied
+     * even if the attribute is not present in the input data.
+     *
+     * @var bool
+     */
+    public bool $implicit = true;
+
+    /**
+     * The model instance used to check for existing translations.
+     *
+     * @param Model $modelObject The model object to validate against.
+     */
+    public function __construct(public Model $modelObject)
+    {
+        //
+    }
+
+    /**
+     * Validates the given attribute to ensure it is required for the specified locale.
+     *
+     * @return void
+     */
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
+    {
+        if (\is_null($value) && $this->modelObject->translationModelClass::where('locale', request()->input('locale'))->doesntExist()) {
+            $fail('validation.required')->translate();
+        }
+    }
+}


### PR DESCRIPTION
- Changes

1. add RequiredForLocale rule at src/Rules to use for request attributes that are REQUIRED to create a translation model instance for a translated model

2. update laravel/framework requirement to version 9.2 in composer.json [To be able to use Illuminate\Contracts\Validation\ValidationRule instead of deprecated Illuminate\Contracts\Validation\Rule and enforce newer php version (starting v8)]