### PR TITLE
refactor validation rules to implement ValidationRule interface

### DIFF
--- a/src/Http/Middleware/TranslatableMiddleware.php
+++ b/src/Http/Middleware/TranslatableMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Mabrouk\Translatable\Http\Middleware;
 
+use Closure;
 use Mabrouk\Translatable\Rules\LocaleRule;
 
 /**
@@ -45,7 +46,7 @@ class TranslatableMiddleware
      * Sets the application's locale based on the `X-locale` header or falls back to the default locale.
      *
      */
-    public function handle($request, \Closure $next)
+    public function handle($request, Closure $next)
     {
         if ($this->availableForTranslationSaving) {
             $request->validate([

--- a/src/Http/Middleware/TranslatableMiddleware.php
+++ b/src/Http/Middleware/TranslatableMiddleware.php
@@ -2,14 +2,32 @@
 
 namespace Mabrouk\Translatable\Http\Middleware;
 
-use Closure;
 use Mabrouk\Translatable\Rules\LocaleRule;
 
+/**
+ * Middleware to handle translation-related functionality in HTTP requests.
+ *
+ * This middleware validates the `locale` parameter in requests and sets the application's
+ * locale based on the `X-locale` header or falls back to the default locale.
+ */
 class TranslatableMiddleware
 {
+    /**
+     * @var array|null The mapping of language codes for locale settings.
+     */
     protected $languageCodes;
+
+    /**
+     * @var bool Indicates whether the request is eligible for translation saving.
+     */
     private $availableForTranslationSaving;
 
+    /**
+     * Constructor to initialize middleware properties.
+     *
+     * Sets the language codes and determines if the request is eligible for translation saving
+     * based on the request method and URL segments.
+     */
     public function __construct()
     {
         $this->languageCodes = config('translatable.locale_codes');
@@ -23,11 +41,11 @@ class TranslatableMiddleware
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
+     * Validates the `locale` parameter if the request is eligible for translation saving.
+     * Sets the application's locale based on the `X-locale` header or falls back to the default locale.
+     *
      */
-    public function handle($request, Closure $next)
+    public function handle($request, \Closure $next)
     {
         if ($this->availableForTranslationSaving) {
             $request->validate([

--- a/src/Rules/LocaleRule.php
+++ b/src/Rules/LocaleRule.php
@@ -2,6 +2,7 @@
 
 namespace Mabrouk\Translatable\Rules;
 
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
 /**
@@ -15,7 +16,7 @@ class LocaleRule implements ValidationRule
      *
      * @return void
      */
-    public function validate(string $attribute, mixed $value, \Closure $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (!\in_array($value, config('translatable.locales'))) {
             $fail(":attribute must be one of [" . \implode(', ', config('translatable.locales')) . "]");

--- a/src/Rules/LocaleRule.php
+++ b/src/Rules/LocaleRule.php
@@ -2,39 +2,23 @@
 
 namespace Mabrouk\Translatable\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 
-class LocaleRule implements Rule
+/**
+ * Validation rule to ensure that the given value
+ * is one of the allowed locales defined in the application's configuration.
+ */
+class LocaleRule implements ValidationRule
 {
     /**
-     * Create a new rule instance.
+     * Validates the given attribute to ensure it matches one of the allowed locales.
      *
      * @return void
      */
-    public function __construct()
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
     {
-        //
-    }
-
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
-    {
-        return \in_array($value, config('translatable.locales'));
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return ':attribute must be one of [' . \implode(', ', config('translatable.locales')) . ']';
+        if (!\in_array($value, config('translatable.locales'))) {
+            $fail(":attribute must be one of [" . \implode(', ', config('translatable.locales')) . "]");
+        }
     }
 }

--- a/src/Rules/UniqueForLocale.php
+++ b/src/Rules/UniqueForLocale.php
@@ -2,6 +2,7 @@
 
 namespace Mabrouk\Translatable\Rules;
 
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
 
@@ -26,7 +27,7 @@ class UniqueForLocale implements ValidationRule
      *
      * @return void
      */
-    public function validate(string $attribute, mixed $value, \Closure $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $databaseColumn = $this->databaseColumn ?: $attribute;
 

--- a/src/Rules/UniqueForLocale.php
+++ b/src/Rules/UniqueForLocale.php
@@ -2,49 +2,41 @@
 
 namespace Mabrouk\Translatable\Rules;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Contracts\Validation\Rule;
 
-class UniqueForLocale implements Rule
+/**
+ * Validation rule to ensure a unique value for a specific locale.
+ */
+class UniqueForLocale implements ValidationRule
 {
-    public Model $modelObject;
-    public string $databaseColumn;
-
     /**
      * Create a new rule instance.
      *
+     * @param Model $modelObject The model object to validate against.
+     * @param string $databaseColumn The corresponding attribute's database column to check (optional).
+     */
+    public function __construct(public Model $modelObject, public string $databaseColumn = '')
+    {
+        //
+    }
+
+    /**
+     * Validates the given attribute value to ensure it is unique for the specified locale.
+     *
      * @return void
      */
-    public function __construct(Model $modelObject, string $databaseColumn = '')
+    public function validate(string $attribute, mixed $value, \Closure $fail): void
     {
-        $this->modelObject = $modelObject;
-        $this->databaseColumn = $databaseColumn;
-    }
+        $databaseColumn = $this->databaseColumn ?: $attribute;
 
-    /**
-     * Determine if the validation rule passes.
-     *
-     * @param  string  $attribute
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function passes($attribute, $value)
-    {
-        $databaseColumn = $this->databaseColumn != null ? $this->databaseColumn : $attribute;
-
-        return $this->modelObject->translationModelClass::where($databaseColumn, $value)
-            ->where('locale', request()->locale)
+        $valueExistsForLocale = $this->modelObject->translationModelClass::where($databaseColumn, $value)
+            ->where('locale', request()->input('locale'))
             ->where('id', '!=', translation_id($this->modelObject))
-            ->count() == 0;
-    }
+            ->exists();
 
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return __('validation.unique');
+        if ($valueExistsForLocale) {
+            $fail('validation.unique')->translate();
+        }
     }
 }

--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -2,6 +2,8 @@
 
 namespace Mabrouk\Translatable\Traits;
 
+use ReflectionClass;
+
 /**
  * Translatable Trait
  *
@@ -206,9 +208,9 @@ trait Translatable
      */
     private function translationModelClass()
     {
-        $translationModelClass = config('translatable.translation_models_path') . '\\' . (new \ReflectionClass($this))->getShortName() . 'Translation';
+        $translationModelClass = config('translatable.translation_models_path') . '\\' . (new ReflectionClass($this))->getShortName() . 'Translation';
         if (!\class_exists($translationModelClass)) {
-            $translationModelClass = (new \ReflectionClass($this))->getName() . 'Translation';
+            $translationModelClass = (new ReflectionClass($this))->getName() . 'Translation';
         }
         return $translationModelClass;
     }

--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -2,34 +2,71 @@
 
 namespace Mabrouk\Translatable\Traits;
 
-use ReflectionClass;
-
-Trait Translatable
+/**
+ * Translatable Trait
+ *
+ * Provides functionality for handling translations in Eloquent models.
+ * This trait allows models to manage translations for attributes,
+ * retrieve translated values, and handle fallback locales.
+ */
+trait Translatable
 {
+    /**
+     * @var string|null The current locale being used for translations.
+     */
     private $locale;
+
+    /**
+     * @var string|null The locale extracted from the request header.
+     */
     private $xLocale;
 
+    /**
+     * Boot the Translatable trait.
+     *
+     * Registers a model event listener to handle translations after the model is saved.
+     *
+     * @return void
+     */
     public static function bootTranslatable()
     {
         static::saved(function ($model) {
-            if (! request()->dontTranslate) {
+            if (!request()->dontTranslate) {
                 return $model->translate(request()->all());
             }
         });
-	}
-
-    public function __get($property)
-    {
-        return \in_array($property, $this->translatedAttributes) ? $this->findTranslatedAttribute($property) : Parent::__get($property);
     }
 
-    // * Define translation model relation
+    /**
+     * Magic method to retrieve translated attributes.
+     *
+     * @param string $property The property name being accessed.
+     * @return mixed The translated value or the parent property value.
+     */
+    public function __get($property)
+    {
+        return \in_array($property, $this->translatedAttributes)
+            ? $this->findTranslatedAttribute($property)
+            : parent::__get($property);
+    }
+
+    /**
+     * Define the relationship to the translation model.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function translations()
     {
         return $this->hasMany($this->translationModelClass);
     }
 
-    // save model translation
+    /**
+     * Save translations for the model.
+     *
+     * @param array $data The data to be translated.
+     * @param string|null $locale The locale for the translation (optional).
+     * @return $this
+     */
     public function translate($data, $locale = null)
     {
         $this->modifyOrMakeTranslation($data, $locale);
@@ -37,22 +74,48 @@ Trait Translatable
         return $this;
     }
 
+    /**
+     * Retrieve a specific translated attribute for a given locale.
+     *
+     * @param string $attribute The attribute name.
+     * @param string|null $locale The locale to retrieve the translation for (optional).
+     * @return mixed The translated attribute value.
+     */
     public function tr($attribute, $locale = null)
     {
         return $this->translations->where('locale', $this->locale($locale))->first()?->$attribute;
     }
 
+    /**
+     * Retrieve the fallback translation for the model.
+     *
+     * @return mixed The fallback translation.
+     */
     public function fallbackTranslation()
     {
         return $this->translations?->where('locale', config('translatable.fallback_locale'))?->first();
     }
 
+    /**
+     * Find the translated value of an attribute.
+     *
+     * @param string $attribute The attribute name.
+     * @return mixed The translated value or the fallback value.
+     */
     public function findTranslatedAttribute($attribute)
     {
         $translation = $this->translations->where('locale', $this->xLocale())->first();
-        return $translation && $translation?->$attribute != null ? $translation?->$attribute : ($this->fallbackTranslation())?->$attribute;
+        return $translation && $translation?->$attribute != null
+            ? $translation?->$attribute
+            : ($this->fallbackTranslation())?->$attribute;
     }
 
+    /**
+     * Delete translations for specific locales.
+     *
+     * @param string ...$params The locales to delete translations for.
+     * @return $this
+     */
     public function deleteTranslations(string ...$params)
     {
         $this->translations()
@@ -63,6 +126,13 @@ Trait Translatable
         return $this;
     }
 
+    /**
+     * Create or update a translation for the model.
+     *
+     * @param array $data The data to be translated.
+     * @param string|null $locale The locale for the translation (optional).
+     * @return $this
+     */
     private function modifyOrMakeTranslation($data, $locale = null)
     {
         $locale = $this->locale($locale);
@@ -79,6 +149,12 @@ Trait Translatable
         return $this;
     }
 
+    /**
+     * Filter the translatable fields from the given data.
+     *
+     * @param array $data The data to filter.
+     * @return array The filtered translatable fields.
+     */
     private function getTranslatableFields($data)
     {
         $filteredData = collect($data)->filter(function ($field, $key) {
@@ -88,6 +164,12 @@ Trait Translatable
         return $filteredData;
     }
 
+    /**
+     * Determine the locale to use for translations.
+     *
+     * @param string|null $locale The locale to use (optional).
+     * @return string The determined locale.
+     */
     private function locale($locale = null)
     {
         if ($this->translations()->count() == 0) {
@@ -95,26 +177,47 @@ Trait Translatable
             return $this->locale;
         }
 
-        $this->locale = $locale != null && \in_array($locale, config('translatable.locales')) ? $locale : request()->locale;
-        $this->locale = $this->locale != null && \in_array($this->locale, config('translatable.locales')) ? $this->locale : config('translatable.fallback_locale');
+        $this->locale = $locale != null && \in_array($locale, config('translatable.locales'))
+            ? $locale
+            : request()->locale;
+        $this->locale = $this->locale != null && \in_array($this->locale, config('translatable.locales'))
+            ? $this->locale
+            : config('translatable.fallback_locale');
         return $this->locale;
     }
 
+    /**
+     * Retrieve the locale from the request header or fallback locale.
+     *
+     * @return string The determined locale.
+     */
     private function xLocale()
     {
-        $this->xLocale = request()->header('X-locale') != null && \in_array(request()->header('X-locale'), config('translatable.locales')) ? request()->header('X-locale') : config('translatable.fallback_locale');
+        $this->xLocale = request()->header('X-locale') != null && \in_array(request()->header('X-locale'), config('translatable.locales'))
+            ? request()->header('X-locale')
+            : config('translatable.fallback_locale');
         return $this->xLocale;
     }
 
+    /**
+     * Determine the translation model class for the current model.
+     *
+     * @return string The translation model class name.
+     */
     private function translationModelClass()
     {
-        $translationModelClass = config('translatable.translation_models_path') . '\\' . (new ReflectionClass($this))->getShortName() . 'Translation';
-        if (! \class_exists($translationModelClass)) {
-            $translationModelClass = (new ReflectionClass($this))->getName() . 'Translation';
+        $translationModelClass = config('translatable.translation_models_path') . '\\' . (new \ReflectionClass($this))->getShortName() . 'Translation';
+        if (!\class_exists($translationModelClass)) {
+            $translationModelClass = (new \ReflectionClass($this))->getName() . 'Translation';
         }
         return $translationModelClass;
     }
 
+    /**
+     * Accessor for the translation model class attribute.
+     *
+     * @return string The translation model class name.
+     */
     public function getTranslationModelClassAttribute()
     {
         return $this->translationModelClass();


### PR DESCRIPTION
- Changes

1. Refactor validation rules to implement Illuminate\Contracts\Validation\ValidationRule instead of deprecated Illuminate\Contracts\Validation\Rule

2. Add doc blocks to fundamental files in order to provide better context and improve future reference